### PR TITLE
prefer-destructuring: AssignmentExpression - object: false

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ See [Airbnb's overarching ESLint config](https://npmjs.com/eslint-config-airbnb)
     },
     AssignmentExpression: {
       array: false,
-      object: true
+      object: false
     }
   },
   {

--- a/rules/es6.js
+++ b/rules/es6.js
@@ -26,7 +26,7 @@ module.exports = {
         },
         AssignmentExpression: {
           array: false,
-          object: true,
+          object: false,
         },
       },
       {


### PR DESCRIPTION
https://stackoverflow.com/questions/32138513/how-to-destruct-an-object-to-an-already-defined-variable

Just feel weird when see something like this:

```js
let a;

({ a } = obj);
```

https://eslint.org/docs/rules/prefer-destructuring

