### PR TITLE
improve import/no-extraneous-dependencies by merging latest airbnb config

### DIFF
--- a/rules/imports.js
+++ b/rules/imports.js
@@ -30,12 +30,32 @@ module.exports = {
       'error',
       {
         devDependencies: [
-          '**/__tests__/*.spec.js',
+          'test/**', // tape, common npm pattern
+          'tests/**', // also common npm pattern
+          'spec/**', // mocha, rspec-like pattern
+          '**/__tests__/**', // jest pattern
+          '**/__mocks__/**', // jest pattern
+          'test.{js,jsx}', // repos with a single test file
+          'test-*.{js,jsx}', // repos with multiple top-level test files
+          '**/*{.,_}{test,spec}.{js,jsx}', // tests where the extension or filename suffix denotes that it is a test
+          '**/jest.config.js', // jest config
+          '**/vue.config.js', // vue-cli config
+          '**/webpack.config.js', // webpack config
+          '**/webpack.config.*.js', // webpack config
+          '**/rollup.config.js', // rollup config
+          '**/rollup.config.*.js', // rollup config
+          '**/gulpfile.js', // gulp config
+          '**/gulpfile.*.js', // gulp config
+          '**/Gruntfile{,.js}', // grunt config
+          '**/protractor.conf.js', // protractor config
+          '**/protractor.conf.*.js', // protractor config
+
+          // overwrite patterns:
           '**/__stories__/*.story.js',
           '**/scripts/*.js',
           '**/test/**/*.js',
-          '**/webpack.config.*.js',
         ],
+        optionalDependencies: false,
       },
     ],
 


### PR DESCRIPTION
https://github.com/airbnb/javascript/blob/d951220399c75099838fc79577033b00530b2b90/packages/eslint-config-airbnb-base/rules/imports.js#L71-L94

This should apply to `**/__mocks/**` and so many others.